### PR TITLE
hlte-common: Add f2fs to /system in fstab

### DIFF
--- a/rootdir/etc/fstab.qcom
+++ b/rootdir/etc/fstab.qcom
@@ -8,6 +8,7 @@
 #<src>                                                <mnt_point>  <type>  <mnt_flags and options>                     <fs_mgr_flags>
 /dev/block/platform/msm_sdcc.1/by-name/boot           /boot            emmc    defaults   defaults
 /dev/block/platform/msm_sdcc.1/by-name/recovery       /recovery        emmc    defaults   defaults
+/dev/block/platform/msm_sdcc.1/by-name/system         /system          f2fs    ro,noatime,nodiratime,background_gc=on,discard,nosuid,nodev            wait
 /dev/block/platform/msm_sdcc.1/by-name/system         /system          ext4    ro,barrier=1                                 wait
 /dev/block/platform/msm_sdcc.1/by-name/userdata       /data            f2fs    noatime,nodiratime,background_gc=on,discard,nosuid,nodev               wait,check,encryptable=footer,length=-16384
 /dev/block/platform/msm_sdcc.1/by-name/userdata       /data            ext4    noatime,nosuid,nodev,barrier=1,data=ordered,nomblk_io_submit,noauto_da_alloc,errors=panic    wait,check,encryptable=footer,length=-16384


### PR DESCRIPTION
Dependent on the following:

updater:format with detected filesystem
https://github.com/temasek/android_bootable_recovery/commit/92a8ab732340c2ac4f04f86f57ceb04b1ee08fb9

tools:ota:don't mount system partition with recovery mount options
https://github.com/temasek/android_build/commit/1d6a0b2ff7aedbb9c960b2a31bd2ccf27c8dc721

Signed-off-by: Janson Kang <temasek71@gmail.com>